### PR TITLE
feat: added user passable dependency array

### DIFF
--- a/src/useFetch.js
+++ b/src/useFetch.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 
-const useFetch = (url, initalData) => {
+const useFetch = (url, initalData, dependeices = []) => {
   const [data, setData] = useState(initalData);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
@@ -17,7 +17,7 @@ const useFetch = (url, initalData) => {
         setError(true);
       })
       .finally(() => setLoading(false));
-  }, []);
+  }, dependeices);
 
   return { data, loading, error };
 };


### PR DESCRIPTION
Allowing the consumer to pass the dependency array can extend the use of this hook to re-run the fetch logic based on the provided dependency. Default set to an empty array